### PR TITLE
use a docker-managed volume instead of a local bind mount for mysql

### DIFF
--- a/duplicator-template/docker-compose.yml
+++ b/duplicator-template/docker-compose.yml
@@ -1,5 +1,8 @@
 version: '2'
 
+volumes:
+        dbvolume:
+
 services:
   wordpress:
     image: drlogout/wordpress-duplicator:v1.0.0
@@ -17,5 +20,5 @@ services:
       MYSQL_PASSWORD: wordpress
       MYSQL_ROOT_PASSWORD: root
     volumes:
-      - "./mysql:/var/lib/mysql"
+      - "dbvolume:/var/lib/mysql"
     restart: always


### PR DESCRIPTION
mariadb and hyper-v don't play nicely on windows 10 with bind mounts (see https://github.com/wodby/mariadb/issues/2), but works fine with volumes. This is a workaround for Windows 10 users, and since the bind mount wasn't using local data anyways (seems like it was just being used as local storage?), the volume configuration is more flexible anyways.